### PR TITLE
Update package.json to include bluebird package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "express": "^4.14.0",
     "express-graphql": "^0.5.3",
     "graphql": "^0.6.2",
-    "mongodb": "^2.2.4"
+    "mongodb": "^2.2.4",
+    "bluebird": "^3.4.6"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
If you clone project, npm install, then npm start it fails with "Error: Cannot find module 'bluebird'". If you add bluebird and rerun, it works.