### PR TITLE
Graphql language

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,7 @@
     'transform-exponentiation-operator',
     // Other
     'transform-runtime',
+    'babel-plugin-inline-import'
   ],
   presets: [
     'es2015-node5',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express": "^4.14.0",
     "express-graphql": "^0.6.3",
     "graphql": "^0.9.1",
+    "graphql-tools": "^0.10.1",
     "mongodb": "^2.2.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,23 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "babel-node ./src/index.js"
+    "start": "babel-node ./src/index.js",
+    "dev": "nodemon --exec 'npm start' -e js,jade,graphql,ts,json"
   },
   "author": "Reindex Software",
   "license": "MIT",
   "dependencies": {
+    "base64-url": "^1.3.2",
+    "bluebird": "^3.5.0",
+    "express": "^4.14.0",
+    "express-graphql": "^0.6.3",
+    "graphql": "^0.9.1",
+    "mongodb": "^2.2.4"
+  },
+  "devDependencies": {
     "babel-cli": "^6.11.4",
+    "babel-eslint": "^7.1.1",
+    "babel-plugin-inline-import": "^2.0.4",
     "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
     "babel-plugin-transform-async-functions": "^6.8.0",
     "babel-plugin-transform-async-to-module-method": "^6.8.0",
@@ -19,16 +30,8 @@
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015-node5": "^1.2.0",
-    "base64-url": "^1.3.2",
-    "bluebird": "^3.5.0",
-    "express": "^4.14.0",
-    "express-graphql": "^0.5.3",
-    "graphql": "^0.6.2",
-    "mongodb": "^2.2.4"
-  },
-  "devDependencies": {
-    "babel-eslint": "^6.1.2",
     "eslint": "^3.1.1",
-    "eslint-plugin-babel": "^3.3.0"
+    "eslint-plugin-babel": "^4.1.1",
+    "nodemon": "^1.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015-node5": "^1.2.0",
     "base64-url": "^1.3.2",
+    "bluebird": "^3.5.0",
     "express": "^4.14.0",
     "express-graphql": "^0.5.3",
     "graphql": "^0.6.2",

--- a/src/Article.js
+++ b/src/Article.js
@@ -22,9 +22,11 @@ export async function getArticles(mongodb, {
 }
 
 function limitQueryWithId(query, before, after, order) {
-  const filter = {
-    _id: {},
-  };
+  const filter = {};
+
+  if (before || after) {
+    filter._id = {};
+  }
 
   if (before) {
     const op = order === 1 ? '$lt' : '$gt';
@@ -36,6 +38,7 @@ function limitQueryWithId(query, before, after, order) {
     filter._id[op] = ObjectId(after.value);
   }
 
+  console.log(filter, order)
   return query.find(filter).sort([['_id', order]]);
 }
 

--- a/src/Article.js
+++ b/src/Article.js
@@ -38,7 +38,6 @@ function limitQueryWithId(query, before, after, order) {
     filter._id[op] = ObjectId(after.value);
   }
 
-  console.log(filter, order)
   return query.find(filter).sort([['_id', order]]);
 }
 

--- a/src/Cursor.js
+++ b/src/Cursor.js
@@ -15,7 +15,11 @@ export function fromCursor(string) {
   }
 }
 
-const CursorType = new GraphQLScalarType({
+export const CursorTypeDef = `
+scalar Cursor
+`;
+
+export const Cursor = new GraphQLScalarType({
   name: 'Cursor',
   serialize(value) {
     if (value.value) {
@@ -35,5 +39,3 @@ const CursorType = new GraphQLScalarType({
     return fromCursor(value);
   },
 });
-
-export default CursorType;

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -3,6 +3,11 @@ import { CursorTypeDef, Cursor } from './Cursor';
 import { getArticles } from './Article';
 import paginatorSchema from './schema.graphql';
 
+const Article = {
+  id(parent) {
+    return parent._id.toString();
+  },
+};
 
 const ArticleConnection = {
   edges(parent) {
@@ -22,10 +27,9 @@ const ArticleEdge = {
 };
 
 const Viewer = {
-  allArticles(parent, args, { mongodb }) {
-    const articles = getArticles(mongodb, args, 'text', -1);
-    console.log(articles);
-    return articles;
+  allArticles(parent, { sortBy, order, ...args }, { mongodb }) {
+    const orderNum = order === 'ASC' ? 1 : -1;
+    return getArticles(mongodb, args, sortBy, orderNum);
   },
 };
 
@@ -40,9 +44,10 @@ const Query = {
 const resolvers = {
   Query,
   Viewer,
-  ArticleEdge,
   Cursor,
+  Article,
   ArticleConnection,
+  ArticleEdge,
 };
 
 const Schema = makeExecutableSchema({

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -3,56 +3,44 @@ import { CursorTypeDef, Cursor } from './Cursor';
 import { getArticles } from './Article';
 import paginatorSchema from './schema.graphql';
 
-const Article = {
-  id(parent) {
-    return parent._id.toString();
-  },
-};
-
-const ArticleConnection = {
-  edges(parent) {
-    return parent.query.toArray();
-  },
-};
-
-const ArticleEdge = {
-  cursor(parent) {
-    return {
-      value: parent._id.toString(),
-    };
-  },
-  node(parent) {
-    return parent;
-  },
-};
-
-const Viewer = {
-  allArticles(parent, { sortBy, order, ...args }, { mongodb }) {
-    const orderNum = order === 'ASC' ? 1 : -1;
-    return getArticles(mongodb, args, sortBy, orderNum);
-  },
-};
-
-const Query = {
-  viewer() {
-    return {
-      id: 'VIEWER_ID',
-    };
-  },
-};
-
 const resolvers = {
-  Query,
-  Viewer,
+  Article: {
+    id({ _id }) {
+      return _id.toString();
+    },
+  },
+  ArticleConnection: {
+    edges({ query }) {
+      return query.toArray();
+    },
+  },
+  ArticleEdge: {
+    cursor({ _id }) {
+      return {
+        value: _id.toString(),
+      };
+    },
+    node(parent) {
+      return parent;
+    },
+  },
+  Viewer: {
+    allArticles(parent, { sortBy, order, ...args }, { mongodb }) {
+      const orderNum = order === 'ASC' ? 1 : -1;
+      return getArticles(mongodb, args, sortBy, orderNum);
+    },
+  },
+  Query: {
+    viewer() {
+      return {
+        id: 'VIEWER_ID',
+      };
+    },
+  },
   Cursor,
-  Article,
-  ArticleConnection,
-  ArticleEdge,
 };
 
-const Schema = makeExecutableSchema({
+export default makeExecutableSchema({
   typeDefs: [paginatorSchema, CursorTypeDef],
   resolvers,
 });
-
-export default Schema;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -18,9 +18,21 @@ type ArticleEdge {
   node: Article
 }
 
+enum sortOrder {
+  ASC
+  DESC
+}
+
 type Viewer {
   id: ID!
-  allArticles: ArticleConnection
+  allArticles (
+    sortBy: String = "text",
+    order: sortOrder = "ASC",
+    first: Int
+    last: Int
+    before: Cursor
+    after: Cursor
+  ): ArticleConnection
 }
 
 type Query {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,0 +1,28 @@
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+}
+
+type Article {
+  id: ID!
+  text: String!
+}
+
+type ArticleConnection {
+  edges: [ArticleEdge]
+  pageInfo: PageInfo!
+}
+
+type ArticleEdge {
+  cursor: Cursor
+  node: Article
+}
+
+type Viewer {
+  id: ID!
+  allArticles: ArticleConnection
+}
+
+type Query {
+  viewer: Viewer
+}


### PR DESCRIPTION
Thank you for this excellent example! I finally have some grasp of this elusive cursor concept.

This pull request is about making the example a little more dense by defining the types in GraphQL. I've found this much easier to read and figured that I'd share this if anyone is interested in taking this approach. I suggest that you add a branch with this solution and perhaps a README that points explains both solutions.

Details:
* I use the babel inline import plugin for loading the graphql files
* The schema is built using `graph-tools` `makeExecutableSchema`.
* I've added some convenience helpers such as nodemon
* I've also fixed a bug in the `limitQueryWithId`
* I've added the missing bluebird dependency and moved all the babel stuff into [dev](http://stackoverflow.com/questions/40143357/do-you-put-babel-and-webpack-in-devdependencies-or-dependencies). The latter is a matter of taste but it nicely separates (in my mind) the core pieces from the fluff

I've tested the code with two articles on my local machine. Some test-cases would perhaps be nice to have, let me know if you want me to add these.